### PR TITLE
[mod] use a list for previous_maintainters in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,10 +15,10 @@
     "name": "jibec",
     "email": "jean-baptiste@holcroft.fr"
   },
-  "previous_maintainers": {
+  "previous_maintainers": [{
     "name": "mbugeia",
     "email": "maxime@max.privy.place"
-  },
+  }],
   "multi_instance": true,
   "services": [
     "nginx",


### PR DESCRIPTION
As discussed here https://github.com/YunoHost/issues/issues/1094 and on IRC with @maniackcrudelis 