### PR TITLE
add missing dependencies

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,3 +3,8 @@
 # Common variables
 #
 
+if [ "$(lsb_release --codename --short)" == "jessie" ]; then
+	pkg_dependencies="php5-gd"
+else
+	pkg_dependencies="php-gd php-zip php-dom php-mbstring"
+fi

--- a/scripts/install
+++ b/scripts/install
@@ -62,10 +62,6 @@ ynh_app_setting_set "$app" is_public "$is_public"
 # INSTALL DEPENDENCIES
 #=================================================
 
-pkg_dependencies="php-gd php-dom php-mbstring"
-if [ "$(lsb_release --codename --short)" != "jessie" ]; then
-	pkg_dependencies="$pkg_dependencies php-zip"
-fi
 ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -62,7 +62,7 @@ ynh_app_setting_set "$app" is_public "$is_public"
 # INSTALL DEPENDENCIES
 #=================================================
 
-pkg_dependencies=php5-gd
+pkg_dependencies="php-gd php-dom php-mbstring"
 if [ "$(lsb_release --codename --short)" != "jessie" ]; then
 	pkg_dependencies="$pkg_dependencies php-zip"
 fi

--- a/scripts/restore
+++ b/scripts/restore
@@ -55,10 +55,6 @@ test ! -d $final_path \
 #=================================================
 
 # Define and install dependencies
-pkg_dependencies=php5-gd
-if [ "$(lsb_release --codename --short)" != "jessie" ]; then
-	pkg_dependencies="$pkg_dependencies php-zip"
-fi
 ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -120,10 +120,6 @@ ynh_add_fpm_config
 # INSTALL DEPENDENCIES
 #=================================================
 
-pkg_dependencies=php5-gd
-if [ "$(lsb_release --codename --short)" != "jessie" ]; then
-	pkg_dependencies="$pkg_dependencies php-zip"
-fi
 ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================


### PR DESCRIPTION
## Problem
- When installing kanboard, I had  a missing mbstring extension. After installing it manually, I had a missing dom extension. error. 
## Solution
- Used php- instead of php7-, it is more generic. php-dom is a alias for php-xml.


## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : 

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/kanboard_ynh%20PR71%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/kanboard_ynh%20PR71%20(Official_fork)/) 
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
