### PR TITLE
set maintainer to yunohost-apps

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,12 +12,14 @@
 		"yunohost": ">= 2.7.0"
   },
   "maintainer": {
-    "name": "jibec",
-    "email": "jean-baptiste@holcroft.fr"
+    "name": "yunohost-apps"
   },
   "previous_maintainers": [{
     "name": "mbugeia",
     "email": "maxime@max.privy.place"
+  },
+  {"name": "jibec",
+    "email": "jean-baptiste@holcroft.fr"
   }],
   "multi_instance": true,
   "services": [

--- a/manifest.json
+++ b/manifest.json
@@ -12,13 +12,15 @@
 		"yunohost": ">= 2.7.0"
   },
   "maintainer": {
-    "name": "yunohost-apps"
+    "name": "YunoHost Contributors",
+    "email": "apps@yunohost.org"
   },
   "previous_maintainers": [{
     "name": "mbugeia",
     "email": "maxime@max.privy.place"
   },
-  {"name": "jibec",
+  {
+    "name": "jibec",
     "email": "jean-baptiste@holcroft.fr"
   }],
   "multi_instance": true,


### PR DESCRIPTION
## Problem
- *this app is official, maintenance is done by yunohost-apps team*
- we should never have changed it the first time

## Solution
- *place my name in old maintainer*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/kanboard_ynh%20Jibec-patch-1%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/kanboard_ynh%20Jibec-patch-1%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
