### PR TITLE
Upgrade to upstream version 1.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ From command line:
 
 Infos
 -----
-Kanboard v1.2.0
+Kanboard v1.2.8
 
 Yunohost forum thread:  <https://forum.yunohost.org/t/kanboard-package/78>
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,4 +1,4 @@
-SOURCE_URL=https://github.com/kanboard/kanboard/archive/v1.2.3.tar.gz
-SOURCE_SUM=e0b013df560bf5f60a6f43bf5499e90ca6e793808e5e0fb48e86ef31a234d062
+SOURCE_URL=https://github.com/kanboard/kanboard/archive/v1.2.8.tar.gz
+SOURCE_SUM=04c1d863918383f53cf98f7a3e989728eecbb90d0ae0d5ebaf0c8a1151b3f771
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "description": {
     "en": "Kanboard is a simple visual task board web application"
   },
-  "version": "1.2.3~ynh1",
+  "version": "1.2.8~ynh1",
   "url": "https://kanboard.net/",
   "license": "AGPL-3.0",
   "requirements": {


### PR DESCRIPTION
## Problem
- *Kanboard version 1.2.8 was just released*

## Solution
- *Upgrade to 1.2.8*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/kanboard_ynh%20enh_upgrade_1.2.8%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/kanboard_ynh%20enh_upgrade_1.2.8%20(Official)/)
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
