### PR TITLE
php-dom -> php7.0-xml

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,4 +4,4 @@
 # COMMON VARIABLES
 #=================================================
 
-pkg_dependencies="php-gd php-zip php-dom php-mbstring"
+pkg_dependencies="php-gd php-zip php7.0-dom php-mbstring"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,4 +4,4 @@
 # COMMON VARIABLES
 #=================================================
 
-pkg_dependencies="php-gd php-zip php7.0-dom php-mbstring"
+pkg_dependencies="php-gd php-zip php7.0-dom php7.0-mbstring"


### PR DESCRIPTION
## Problem

c.f. https://forum.yunohost.org/t/l-operation-installer-l-application-kanboard-a-echoue/11753

apt is fukin dumb and refused to see php-dom as installed even though it's provided by php7.0-xml which is already installed ...

## Solution

Require php7.0-xml instead of php-dom, because php7.0-xml is the package that provides php-dom.

