### PR TITLE
Upgrade to upstream version 1.2.14 / use PHP 7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to
 ## Overview
 Kanboard is a simple visual task board web application.
 
-**Shipped version:** 1.2.12
+**Shipped version:** 1.2.14
 
 ## Screenshots
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/kanboard/kanboard/archive/v1.2.12.tar.gz
-SOURCE_SUM=6b17a4cfcf2402e69e49826b248c284f5ed84b02aaf054743c2a46f4af2f9fa3
+SOURCE_URL=https://github.com/kanboard/kanboard/archive/v1.2.14.tar.gz
+SOURCE_SUM=9e771421b2ac77b42c462532974c17c278c472700b0af7b00a01ea0883217080
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/config.php
+++ b/conf/config.php
@@ -234,3 +234,14 @@ define('HTTP_VERIFY_SSL_CERTIFICATE', false);
 
 // TOTP (2FA) issuer name
 define('TOTP_ISSUER', 'Kanboard');
+
+// Comma separated list of fields to not synchronize when using external authentication providers
+define('EXTERNAL_AUTH_EXCLUDE_FIELDS', 'username');
+
+// Enable or disable displaying group-memberships in userlist (true by default)
+define('SHOW_GROUP_MEMBERSHIPS_IN_USERLIST', true);
+
+// Limit number of groups to display in userlist (The full list of group-memberships is always shown, ...
+// ... when hovering the mouse over the group-icon of a given user!)
+// If set to 0 ALL group-memberships will be listed (7 by default)
+define('SHOW_GROUP_MEMBERSHIPS_IN_USERLIST_WITH_LIMIT', 7);

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -18,12 +18,13 @@ location __PATH__/ {
 
 	location ~ [^/]\.php(/|$) {
 		fastcgi_split_path_info ^(.+?\.php)(/.*)$;
-		fastcgi_pass unix:/var/run/php/php7.0-fpm-__NAME__.sock;
+		fastcgi_pass unix:/var/run/php/php__PHPVERSION__-fpm-__NAME__.sock;
 		fastcgi_index index.php;
 		include fastcgi_params;
 		fastcgi_param REMOTE_USER $remote_user;
 		fastcgi_param PATH_INFO $fastcgi_path_info;
 		fastcgi_param SCRIPT_FILENAME $request_filename;
+        fastcgi_param SERVER_NAME $host;
 	}
 
 	# Include SSOWAT user panel.

--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -33,7 +33,7 @@ group = __USER__
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /var/run/php/php7.0-fpm-__NAMETOCHANGE__.sock
+listen = /var/run/php/php__PHPVERSION__-fpm-__NAMETOCHANGE__.sock
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on FreeBSD and OpenBSD)

--- a/manifest.json
+++ b/manifest.json
@@ -3,9 +3,9 @@
   "id": "kanboard",
   "packaging_format": 1,
   "description": {
-    "en": "Kanboard is a simple visual task board web application"
+    "en": "Free and open source Kanban project management software"
   },
-  "version": "1.2.12~ynh1",
+  "version": "1.2.14~ynh1",
   "url": "https://kanboard.net/",
   "license": "AGPL-3.0",
   "maintainer": {
@@ -13,7 +13,7 @@
     "email": "apps@yunohost.org"
   },
   "requirements": {
-    "yunohost": ">= 3.5.0"
+    "yunohost": ">= 3.8.1"
   },
   "previous_maintainers": [{
     "name": "mbugeia",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,5 +3,5 @@
 #=================================================
 # COMMON VARIABLES
 #=================================================
-
-pkg_dependencies="php-gd php-zip php-dom php-mbstring"
+YNH_PHP_VERSION="7.3"
+extra_php_dependencies="php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-zip php${YNH_PHP_VERSION}-dom php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-mysql"

--- a/scripts/backup
+++ b/scripts/backup
@@ -48,7 +48,7 @@ ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 ynh_script_progression --message="Backing up php-fpm configuration..."
 
-ynh_backup --src_path="/etc/php/7.0/fpm/pool.d/$app.conf"
+ynh_backup --src_path="/etc/php/$YNH_PHP_VERSION/fpm/pool.d/$app.conf"
 
 #=================================================
 # BACKUP FAIL2BAN CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -51,11 +51,6 @@ ynh_app_setting_set --app=$app --key=is_public --value=$is_public
 #=================================================
 # STANDARD MODIFICATIONS
 #=================================================
-# INSTALL DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Installing dependencies..." --weight=14
-
-ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================
 # CREATE A MYSQL DATABASE
@@ -96,10 +91,10 @@ ynh_system_user_create --username=$app
 #=================================================
 # PHP-FPM CONFIGURATION
 #=================================================
-ynh_script_progression --message="Configuring php-fpm..." --weight=2
+ynh_script_progression --message="Configuring php-fpm..." --weight=16
 
 # Create a dedicated php-fpm config
-ynh_add_fpm_config
+ynh_add_fpm_config --phpversion=$YNH_PHP_VERSION --package="$extra_php_dependencies"
 
 #=================================================
 # SPECIFIC SETUP
@@ -127,6 +122,11 @@ ynh_replace_string --match_string="__DOMAIN__"  --replace_string=$domain  --targ
 ynh_script_progression --message="Initializing database..." --weight=7
 
 ynh_mysql_connect_as --user="$db_name" --password="$db_pwd" --database="$db_name" < "${final_path}/app/Schema/Sql/mysql.sql"
+(
+	cd "$final_path"
+	# Launch database migration
+	php$YNH_PHP_VERSION cli db:migrate --no-interaction --verbose
+)
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -19,7 +19,7 @@ ynh_abort_if_errors
 #=================================================
 # LOAD SETTINGS
 #=================================================
-ynh_script_progression --message="Loading settings..." --weight=2
+ynh_script_progression --message="Loading installation settings..." --weight=2
 
 app=$YNH_APP_INSTANCE_NAME
 
@@ -72,16 +72,17 @@ chown -R $app $final_path/{data,plugins,sessions}
 # RESTORE THE PHP-FPM CONFIGURATION
 #=================================================
 
-ynh_restore_file --origin_path="/etc/php/7.0/fpm/pool.d/$app.conf"
+ynh_script_progression --message="Reconfiguring php-fpm..." --weight=6
+
+# Restore the file first, so it can have a backup if different
+ynh_restore_file --origin_path="/etc/php/$YNH_PHP_VERSION/fpm/pool.d/$app.conf"
+
+# Recreate a dedicated php-fpm config
+ynh_add_fpm_config --phpversion=$YNH_PHP_VERSION --package="$extra_php_dependencies"
 
 #=================================================
 # SPECIFIC RESTORATION
 #=================================================
-# REINSTALL DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Reinstalling dependencies..." --weight=13
-
-ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================
 # RESTORE THE MYSQL DATABASE
@@ -106,9 +107,8 @@ ynh_systemd_action --action=restart --service_name=fail2ban
 #=================================================
 # RELOAD NGINX AND PHP-FPM
 #=================================================
-ynh_script_progression --message="Reloading nginx web server and php-fpm..." --weight=2
+ynh_script_progression --message="Reloading nginx web server..." --weight=2
 
-ynh_systemd_action --service_name=php7.0-fpm --action=reload
 ynh_systemd_action --service_name=nginx --action=reload
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -114,14 +114,7 @@ ynh_system_user_create --username=$app
 ynh_script_progression --message="Upgrading php-fpm configuration..."
 
 # Create a dedicated php-fpm config
-ynh_add_fpm_config
-
-#=================================================
-# UPGRADE DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Upgrading dependencies..." --weight=6
-
-ynh_install_app_dependencies $pkg_dependencies
+ynh_add_fpm_config --phpversion="$YNH_PHP_VERSION" --package="$extra_php_dependencies"
 
 #=================================================
 # SPECIFIC UPGRADE
@@ -154,9 +147,9 @@ ynh_script_progression --message="Upgrading kanboard..." --weight=2
 (
 	cd "$final_path"
 	# Launch database migration
-	php cli db:migrate --no-interaction --verbose
+	php$YNH_PHP_VERSION cli db:migrate --no-interaction --verbose
 	# Launch plugins migration
-	php cli plugin:upgrade --no-interaction --verbose
+	php$YNH_PHP_VERSION cli plugin:upgrade --no-interaction --verbose
 )
 
 #=================================================


### PR DESCRIPTION
## Problem
- *The application is not up-to-date with the upstream*
- *upstream versions require PHP 7.3*

## Solution
- *Upgrade to latest upstream version 1.2.14*
- *Use latest PHP helpers from YunoHost 3.8 to use PHP 7.3*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : yalh76
- [x] **Approval (LGTM)** : yalh76
- [x] **Approval (LGTM)** : ericgaspar
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/kanboard_ynh%20PR95/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/kanboard_ynh%20PR95/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
