### PR TITLE
Fix config.php migration and SSO

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -292,7 +292,6 @@ define('TRUSTED_PROXY_HEADERS', '');
 
 // Comma separated list of trusted proxy IP networks (CIDR), for example: "192.168.0.0/16,10.0.0.0/8,::1/128"
 define('TRUSTED_PROXY_NETWORKS', '127.0.0.1/32,::1/128');
-var_dump(TRUSTED_PROXY_NETWORKS);
 
 // Allow private network access when fetching metadata for external links
 define('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS', false);

--- a/conf/config.php
+++ b/conf/config.php
@@ -291,7 +291,7 @@ define('DASHBOARD_MAX_PROJECTS', 10);
 define('TRUSTED_PROXY_HEADERS', '');
 
 // Comma separated list of trusted proxy IP networks (CIDR), for example: "192.168.0.0/16,10.0.0.0/8,::1/128"
-define('TRUSTED_PROXY_NETWORKS', '127.0.0.1');
+define('TRUSTED_PROXY_NETWORKS', '127.0.0.1/32,::1/128');
 
 // Allow private network access when fetching metadata for external links
 define('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS', false);

--- a/conf/config.php
+++ b/conf/config.php
@@ -292,6 +292,7 @@ define('TRUSTED_PROXY_HEADERS', '');
 
 // Comma separated list of trusted proxy IP networks (CIDR), for example: "192.168.0.0/16,10.0.0.0/8,::1/128"
 define('TRUSTED_PROXY_NETWORKS', '127.0.0.1/32,::1/128');
+var_dump(TRUSTED_PROXY_NETWORKS);
 
 // Allow private network access when fetching metadata for external links
 define('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS', false);

--- a/conf/config.php
+++ b/conf/config.php
@@ -296,3 +296,6 @@ var_dump(TRUSTED_PROXY_NETWORKS);
 
 // Allow private network access when fetching metadata for external links
 define('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS', false);
+
+// Allow private network access for webhook notifications
+define('WEBHOOK_ALLOW_PRIVATE_NETWORKS', false);

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -18,6 +18,6 @@ location __PATH__/ {
   
   location ~ [^/]\.php(/|$) {
     fastcgi_pass unix:/var/run/php/php__PHP_VERSION__-fpm-__APP__.sock;
-    include fastcgi_params_no_auth;
+    include fastcgi_params_with_auth;
   }
 }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -19,7 +19,6 @@ location __PATH__/ {
   location ~ [^/]\.php(/|$) {
     fastcgi_pass unix:/var/run/php/php__PHP_VERSION__-fpm-__APP__.sock;
     include fastcgi_params_no_auth;
-    fastcgi_param SERVER_NAME $host;
     fastcgi_pass_header Authorization;
   }
 }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -18,7 +18,7 @@ location __PATH__/ {
   
   location ~ [^/]\.php(/|$) {
     fastcgi_pass unix:/var/run/php/php__PHP_VERSION__-fpm-__APP__.sock;
-    include fastcgi_params_no_auth;
+    include fastcgi_params_with_auth;
     fastcgi_pass_header Authorization;
   }
 }

--- a/manifest.toml
+++ b/manifest.toml
@@ -23,7 +23,7 @@ helpers_version = "2.1"
 architectures = "all"
 multi_instance = true
 
-ldap = false
+ldap = true
 sso = false
 
 disk = "50M"

--- a/manifest.toml
+++ b/manifest.toml
@@ -24,7 +24,7 @@ architectures = "all"
 multi_instance = true
 
 ldap = true
-sso = false
+sso = true
 
 disk = "50M"
 ram.build = "50M"

--- a/scripts/install
+++ b/scripts/install
@@ -48,7 +48,7 @@ ynh_script_progression "Initializing database..."
 ynh_mysql_db_shell < "$install_dir/app/Schema/Sql/mysql.sql"
 
 pushd $install_dir
-	php$php_version cli db:migrate --no-interaction --verbose
+    php$php_version cli db:migrate --no-interaction --verbose
 popd
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -9,6 +9,30 @@ ynh_script_progression "Ensuring downward compatibility..."
 
 ynh_app_setting_set_default --key=php_upload_max_filesize --value=100M
 
+# Upgrade existing config.php to v1.2.52 standards 
+if ynh_app_upgrading_from_version_before_or_equal_to 1.2.48~ynh1; then
+    sed -i "/Available cache drivers/d" "$install_dir/config.php"
+    sed -i "/CACHE_DRIVER/d" "$install_dir/config.php"
+    sed -i "/MAIL_SMTP_PASSWORD/a define('MAIL_SMTP_HELO_NAME', null); // valid: null (default), or FQDN" "$install_dir/config.php"
+    cat << EOF | sed -i "/SHOW_GROUP_MEMBERSHIPS_IN_USERLIST_WITH_LIMIT/r /dev/stdin" "$install_dir/config.php"
+
+// Maximum number of projects displayed in the dashboard
+define('DASHBOARD_MAX_PROJECTS', 10);
+
+// Comma separated list of trusted proxy headers, for example: "HTTP_X_REAL_IP,HTTP_X_FORWARDED_FOR"
+define('TRUSTED_PROXY_HEADERS', '');
+
+// Comma separated list of trusted proxy IP networks (CIDR), for example: "192.168.0.0/16,10.0.0.0/8,::1/128"
+define('TRUSTED_PROXY_NETWORKS', '127.0.0.1/32,::1/128');
+
+// Allow private network access when fetching metadata for external links
+define('EXTERNAL_LINK_ALLOW_PRIVATE_NETWORKS', false);
+
+// Allow private network access for webhook notifications
+define('WEBHOOK_ALLOW_PRIVATE_NETWORKS', false);
+EOF
+fi
+
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
@@ -34,20 +58,12 @@ ynh_config_add_fail2ban --logpath="/var/log/nginx/${domain}-error.log" --failreg
 ynh_config_add --template="cron" --destination="/etc/cron.d/$app"
 
 #=================================================
-# ADD A CONFIGURATION
-#=================================================
-ynh_script_progression "Adding $app's configuration..."
-
-#dir="__DIR__"
-#ynh_config_add --template="config.php" --destination="$install_dir/config.php"
-
-#=================================================
 # UPGRADE KANBOARD
 #=================================================
 ynh_script_progression "Upgrading the app..."
 
 pushd $install_dir
-	php$php_version cli db:migrate --no-interaction --verbose
+    php$php_version cli db:migrate --no-interaction --verbose
 popd
 
 #=================================================

--- a/tests.toml
+++ b/tests.toml
@@ -2,6 +2,8 @@ test_format = 1.0
 
 [default]
 
+    exclude = ["install.subdir", "install.nourl", "backup_restore","change_url", "install.multi"]
+
     # -------------------------------
     # Default args to use for install
     # -------------------------------

--- a/tests.toml
+++ b/tests.toml
@@ -2,8 +2,6 @@ test_format = 1.0
 
 [default]
 
-    exclude = ["install.subdir", "install.nourl", "backup_restore","change_url", "install.multi"]
-
     # -------------------------------
     # Default args to use for install
     # -------------------------------
@@ -15,4 +13,3 @@ test_format = 1.0
     # -------------------------------
 
     test_upgrade_from.d9beaa2fa546a3c2acce2457d8d817bcbbbdd520.name = "Upgrade from 1.2.35~ynh3"
-    test_upgrade_from.aec172574020c4fd342aecd700f89b8a43281870.name = "Upgrade from 1.2.48~ynh1"

--- a/tests.toml
+++ b/tests.toml
@@ -2,8 +2,6 @@ test_format = 1.0
 
 [default]
 
-    exclude = ["install.root", "install.subdir", "install.nourl", "backup_restore","change_url", "install.multi"]
-
     # -------------------------------
     # Default args to use for install
     # -------------------------------

--- a/tests.toml
+++ b/tests.toml
@@ -2,6 +2,8 @@ test_format = 1.0
 
 [default]
 
+    exclude = ["install.root", "install.subdir", "install.nourl", "backup_restore","change_url", "install.multi"]
+
     # -------------------------------
     # Default args to use for install
     # -------------------------------
@@ -12,4 +14,5 @@ test_format = 1.0
     # Commits to test upgrade from
     # -------------------------------
 
-    #test_upgrade_from.d9beaa2fa546a3c2acce2457d8d817bcbbbdd520.name = "Upgrade from 1.2.35~ynh3"
+    test_upgrade_from.d9beaa2fa546a3c2acce2457d8d817bcbbbdd520.name = "Upgrade from 1.2.35~ynh3"
+    test_upgrade_from.aec172574020c4fd342aecd700f89b8a43281870.name = "Upgrade from 1.2.48~ynh1"


### PR DESCRIPTION
## Problems

- `v1.2.52~ynh1` introduced upstream's changes in config.php template, which comes together with consistency checks. However in the upgrade script it just keep the old config.php without updating it, thus throwing this error message: https://github.com/kanboard/kanboard/blob/1a9a32da1118a095325ecec50d4c0a784dcd46f8/app/check_setup.php#L48
- Use IP instead of CIDR for TRUSTED_PROXY_NETWORKS 
- Manifest warnings (LDAP setting in manifest.toml + HTTP header duplicate in nginx.conf)
- SSO being used, it's we need nginx param with auth

## Solutions

- Kept old config.php in upgrade script because it may contain custom configuration, but made sure it include new upstream-defined constants (in particular `TRUSTED_PROXY_NETWORKS`) 
- Use CIDR as in [upstream doc](https://docs.kanboard.org/v1/admin/reverse_proxy_authentication/#:~:text=if%20your%20reverse%20proxy%20operates) instead of IP as default TRUSTED_PROXY_NETWORKS value.
- Fix manifest warnings
- change `fastcgi_params_no_auth` for `fastcgi_params_with_auth` in nginx config

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
