### PR TITLE
[Fix] SSO login (REMOTE_USER not forwarded) and 502 on upgrade to 1.2.52

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -17,7 +17,18 @@ location __PATH__/ {
   try_files $uri $uri/ __PATH__/index.php;
   
   location ~ [^/]\.php(/|$) {
+    fastcgi_buffers 16 16k;
+    fastcgi_buffer_size 32k;
     fastcgi_pass unix:/var/run/php/php__PHP_VERSION__-fpm-__APP__.sock;
     include fastcgi_params_no_auth;
+
+    # Forward the SSO-authenticated user, except on /login where we must
+    # never trust proxy auth (this is the route that must stay reachable
+    # without a valid SSO session, e.g. to show a fallback local login form).
+    set $kanboard_remote_user $http_ynh_user;
+    if ($request_uri ~* "^__PATH__/login") {
+      set $kanboard_remote_user "";
+    }
+    fastcgi_param REMOTE_USER $kanboard_remote_user if_not_empty;
   }
 }

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Kanboard"
 description.en = "Kanban project management software"
 description.fr = "Logiciel de gestion de projet Kanban"
 
-version = "1.2.52~ynh2"
+version = "1.2.52~ynh3"
 
 maintainers = []
 


### PR DESCRIPTION
Fixes #233

## What this does

Fixes the blank page / broken SSO login reported in #233, and the 502 Bad Gateway that appears on upgrade to `1.2.52~ynh2`.

### 1. 502 Bad Gateway after upgrade

nginx was logging `upstream sent too big header while reading response header from upstream`. Kanboard 1.2.52 sends larger response headers than before, and the default fastcgi buffers are too small to hold them.

Fix: increased `fastcgi_buffers` / `fastcgi_buffer_size` in the PHP location block.

### 2. Blank page after SSO login

Root cause: the app's nginx vhost has a single `location` block for all PHP requests, and it includes YunoHost's shared `fastcgi_params_no_auth` — which never forwards `REMOTE_USER` at all. This means `REVERSE_PROXY_AUTH` could never succeed anywhere in the app (not just on `/login`, but on the authenticated root `/` too), regardless of `TRUSTED_PROXY_NETWORKS` or LDAP plugin config. This was likely already broken before the 1.2.52 upgrade — the upgrade just made it visible.

Since `try_files` internally rewrites every request to `index.php`, splitting into two separate `location` blocks (one for `/login`, one for the rest) doesn't work — nginx only sees `index.php` after the rewrite. Instead, this patch keeps a single PHP block and uses `$request_uri` (which preserves the original URI even after internal rewrite) to conditionally forward `REMOTE_USER` everywhere except `/login`, where proxy auth must never be trusted.

## Testing

Verified on a production instance that had this exact issue after upgrading from `1.2.48~ynh1`: after applying this patch, SSO login redirects correctly and Kanboard loads as expected; `/login` still correctly receives no `REMOTE_USER` header. Not yet tested in a clean YunoHost dev VM/LXC — happy to do so if a maintainer wants that before merging, or if someone else can confirm on a fresh install.

## Note on AI assistance

:warning:  
**This patch was developed with help from Claude (Anthropic)** — both for the debugging session that isolated the root cause (step-by-step log analysis and temporary code instrumentation on a live instance to trace exactly where `REMOTE_USER` was getting dropped) and for drafting this diff and description. I understand and can explain every part of this change; happy to discuss the approach or adjust it based on maintainer feedback.
:warning: 